### PR TITLE
[APPAI-1733] Use head ref to create PR across repos

### DIFF
--- a/rudra/utils/github.py
+++ b/rudra/utils/github.py
@@ -57,8 +57,8 @@ class Github:
                                         current_sha, branch=f'refs/heads/{branch_name}')
         return update['commit'].sha
 
-    def create_pr(self, branch_name: str, title: str, body: str) -> str:
+    def create_pr(self, head_ref: str, title: str, body: str) -> str:
         """Raise the PR to merge changes from branch to master."""
-        pr = self._repo.create_pull(title=title, body=body, head=f'refs/heads/{branch_name}',
+        pr = self._repo.create_pull(title=title, body=body, head=head_ref,
                                     base=f'refs/heads/{self._master_ref}')
         return pr.number


### PR DESCRIPTION
# Description

Create PR function enhanced to take head reference to create PR across repos.

Fixes # (issue)
This feature is required by Jira ticket https://issues.redhat.com/browse/APPAI-1733
 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
